### PR TITLE
fix display and memory speed issue

### DIFF
--- a/About This Hack/HardwareCollectors/HCRAM.swift
+++ b/About This Hack/HardwareCollectors/HCRAM.swift
@@ -54,12 +54,8 @@ class HCRAM {
         }
         
         let lines = content.components(separatedBy: .newlines)
-        let type = lines.first { $0.contains("Type") }?.components(separatedBy: " ").last ?? ""
-        let speed = lines.first { $0.contains("Speed") && $0.contains("MHz") }?
-            .components(separatedBy: " ")
-            .dropFirst()
-            .prefix(2)
-            .joined(separator: " ") ?? ""
+        let type = lines.first { $0.contains("Type") }?.components(separatedBy: ": ").last ?? ""
+        let speed = lines.first { $0.contains("Speed") && $0.contains("MHz") }?.components(separatedBy: ": ").last ?? ""
         
         return (type, speed)
     }

--- a/About This Hack/ViewController.swift
+++ b/About This Hack/ViewController.swift
@@ -15,6 +15,7 @@ class ViewController: NSViewController {
     @IBOutlet private weak var serialNumber: NSTextField!
     @IBOutlet private weak var serialToggle: NSButton!
     @IBOutlet private weak var blVersion: NSTextField!
+    @IBOutlet private weak var blVersionToggle: NSButton!
     @IBOutlet private weak var blPrefix: NSTextField!
     @IBOutlet private weak var creditText: NSTextField!
     @IBOutlet private weak var btSysInfo: NSButton!
@@ -70,6 +71,7 @@ class ViewController: NSViewController {
         serialNumber.stringValue = HCSerialNumber.shared.getSerialNumber()
         blVersion.stringValue = HCBootloader.shared.getBootloader()
         serialToggle.isTransparent = true
+        blVersionToggle.isTransparent = true
         
         CATransaction.commit()
     }
@@ -110,7 +112,17 @@ class ViewController: NSViewController {
     
     // MARK: - IBActions
     @IBAction func hideSerialNumber(_ sender: NSButton) {
-        serialNumber.stringValue = serialNumber.stringValue.isEmpty ? HCSerialNumber.shared.getSerialNumber() : ""
+        serialNumber.stringValue = (serialNumber.stringValue == "▇▇▇▇▇▇▇▇") ? HCSerialNumber.shared.getSerialNumber() : "▇▇▇▇▇▇▇▇"
+    }
+    
+    @IBAction func hideBlVersion(_ sender: NSButton) {
+        if (blPrefix.stringValue == "") {
+            blPrefix.stringValue = "Bootloader"
+            blVersion.stringValue = HCBootloader.shared.getBootloader()
+        } else {
+            blPrefix.stringValue = ""
+            blVersion.stringValue = ""
+        }
     }
     
     @IBAction func showSystemReport(_ sender: NSButton) {

--- a/About This Hack/ViewControllerDisplays.swift
+++ b/About This Hack/ViewControllerDisplays.swift
@@ -81,7 +81,9 @@ class ViewControllerDisplays: NSViewController {
             nameField.stringValue = trimmedName
             print("DisplayName: \"\(trimmedName)\"")
             
-            setDisplayImage(imageView, for: trimmedName)
+            if (!(index == 0 && HardwareCollector.shared.hasBuiltInDisplay)) {
+                setDisplayImage(imageView, for: trimmedName)
+            }
         }
         
         if index < HardwareCollector.shared.displayRes.count {

--- a/About This Hack/en.lproj/Main.storyboard
+++ b/About This Hack/en.lproj/Main.storyboard
@@ -444,11 +444,23 @@
                                     <action selector="hideSerialNumber:" target="f5d-9Y-QYV" id="ZOz-KY-9Oj"/>
                                 </connections>
                             </button>
+                            <button focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8bQ-4Z-3Cr">
+                                <rect key="frame" x="231" y="37" width="337" height="32"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                <buttonCell key="cell" type="push" bezelStyle="rounded" alignment="center" borderStyle="border" focusRingType="none" imageScaling="proportionallyDown" inset="2" id="udU-Nt-QmA">
+                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="hideBlVersion:" target="f5d-9Y-QYV" id="cVh-da-6B1"/>
+                                </connections>
+                            </button>
                         </subviews>
                     </view>
                     <connections>
                         <outlet property="blPrefix" destination="znt-Qx-7tD" id="ZdX-FL-Dvh"/>
                         <outlet property="blVersion" destination="IuZ-wD-zIo" id="eqo-4Z-ZWR"/>
+                        <outlet property="blVersionToggle" destination="8bQ-4Z-3Cr" id="rZD-vb-xst"/>
                         <outlet property="btSoftUpd" destination="C4y-y2-XtL" id="M6z-79-c3D"/>
                         <outlet property="btSysInfo" destination="9bU-5I-G69" id="8IN-2p-ydT"/>
                         <outlet property="cpu" destination="afk-bp-wk1" id="IBN-uD-tnp"/>


### PR DESCRIPTION
1. Displays Scene
Before: ❌(display names and resolutions are totally messed up)
<img width="580" alt="010516@2x" src="https://github.com/user-attachments/assets/cd27f86d-d247-47d0-a81b-b6f62e4fa76b">

After: ✅
<img width="580" alt="011346@2x" src="https://github.com/user-attachments/assets/fe63087b-0201-4f14-92ae-eb87c373a127">

2. Overview Scene
1)Fix memory speed
2)When hide SN, change SN to "▇▇▇".
3)New feature: click to hide booloader info.
<img width="580" alt="013418@2x" src="https://github.com/user-attachments/assets/d9559e8a-26d6-4247-bf4a-449c67f6a395">
