### PR TITLE
Hide patchVersion when it is equal to 0, as Apple usually does

### DIFF
--- a/About This Hack/HardwareCollectors/HCVersion.swift
+++ b/About This Hack/HardwareCollectors/HCVersion.swift
@@ -25,7 +25,11 @@ class HCVersion {
 
     private func getOSNumber() -> String {
         let osVersion = ProcessInfo.processInfo.operatingSystemVersion
-        return "\(osVersion.majorVersion).\(osVersion.minorVersion).\(osVersion.patchVersion)"
+        if (osVersion.patchVersion == 0) {
+            return "\(osVersion.majorVersion).\(osVersion.minorVersion)"
+        } else {
+            return "\(osVersion.majorVersion).\(osVersion.minorVersion).\(osVersion.patchVersion)"
+        }
     }
   
     private func getOSBuild() -> String {


### PR DESCRIPTION
![101246](https://github.com/user-attachments/assets/500ca76d-a714-4f6c-8c11-29501a539fe7)
