### PR TITLE
Bug fix: in some cases, the value of blPrefix.stringValue is empty

### DIFF
--- a/About This Hack/ViewController.swift
+++ b/About This Hack/ViewController.swift
@@ -72,6 +72,8 @@ class ViewController: NSViewController {
         blVersion.stringValue = HCBootloader.shared.getBootloader()
         serialToggle.isTransparent = true
         blVersionToggle.isTransparent = true
+        blPrefix.isHidden = false
+        blVersion.isHidden = false
         
         CATransaction.commit()
     }
@@ -116,12 +118,12 @@ class ViewController: NSViewController {
     }
     
     @IBAction func hideBlVersion(_ sender: NSButton) {
-        if (blPrefix.stringValue == "") {
-            blPrefix.stringValue = "Bootloader"
-            blVersion.stringValue = HCBootloader.shared.getBootloader()
+        if (blPrefix.isHidden) {
+            blPrefix.isHidden = false
+            blVersion.isHidden = false
         } else {
-            blPrefix.stringValue = ""
-            blVersion.stringValue = ""
+            blPrefix.isHidden = true
+            blVersion.isHidden = true
         }
     }
     


### PR DESCRIPTION
When click to hide bootloader version and then switch top tabs, blPrefix.stringValue will be empty.

![1730272044359](https://github.com/user-attachments/assets/99916f4d-8ae5-43eb-b2e2-abb65c864d1a)
