### PR TITLE
bdmesg not needed for Clover detection

### DIFF
--- a/About This Hack/HardwareCollectors/HCBootloader.swift
+++ b/About This Hack/HardwareCollectors/HCBootloader.swift
@@ -10,11 +10,10 @@ class HCBootloader {
         if !openCoreVersion.isEmpty {
             return run("echo \"OpenCore \"$(nvram \(InitGlobVar.nvramOpencoreVersion) 2>/dev/null | awk '{print $2}' | awk -F'-' '{print $2}' | sed -e 's/ */./g' -e s'/^.//g' -e 's/.$//g' -e 's/ .//g' -e 's/. //g' | tr -d '\n') $( nvram \(InitGlobVar.nvramOpencoreVersion) 2>/dev/null | awk '{print $2}' | awk -F'-' '{print $1}' | sed -e 's/REL/(Release)/g' -e s'/N\\/A//g' -e 's/DEB/(Debug)/g' | tr -d '\n')")
         } else {
-            let cloverInfo = run("\(InitGlobVar.bdmesgExecID) | grep -i \"Starting Clover revision:\" | awk -F 'Starting Clover revision:' '{print $NF}'  | awk '{print \"Clover r\"$1\" (\"substr($4,1,7)\") \"}' | tr -d '\n'")
+            let cloverInfo = "Clover " + run ("cat \(InitGlobVar.hwFilePath) | grep Clover | cut -d \":\" -f2")
             
             if !cloverInfo.isEmpty {
-                let additionalInfo = run("echo $(\(InitGlobVar.bdmesgExecID) | grep -i \"Build with: \\[Args:\" | awk -F '\\-b' '{print $NF}' |  awk -F '\\-t' '{print $1,$2}' |  awk '{print toupper(substr($2,0,1))tolower(substr($2,2)),toupper(substr($1,0,1))tolower(substr($1,2))}') $(\(InitGlobVar.bdmesgExecID) | grep -i \"Build id:\" | awk -F 'Build id:' '{print $NF}' | awk -F '-' '{print  substr($1,1,5)\"/\"substr($1,6,2)\"/\"substr($1,8,2)\" \"substr($1,10,2)\":\"substr($1,12,2)\":\"substr($1,14,2)}'  | tr -d '\n')")
-                return cloverInfo + additionalInfo
+                return cloverInfo
             } else {
                 return run("sysctl -n machdep.cpu.brand_string").contains("Apple") ? "Apple iBoot" : "Apple UEFI"
             }


### PR DESCRIPTION
Good afternoon. If I'm not mistaken, Clover detection relies on the presence of `bdmesg` (`/usr/local/bin/bdmesg`) which does not always exist. `bdmesg` is included in some of the packages available for download on the Clover site.

If the user installs Clover from the installer package, there is an option to add `bdmesg` to the path.

But if the user installs Clover manually, `bdmesg` has to be copied to `/usr/local/bin` explicitly by the user and in many cases this does not happen. As a result, boot loader info fails and shows `Apple UEFI` as boot loader because it did not find OpenCore (it does not exist) nor Clover (`bdmesg` not found in its path).

The fix of course is to copy the file (included on the [Clover releases page](https://github.com/CloverHackyColor/CloverBootloader/releases), utils.zip asset), once this is done ATH shows Clover as the boot loader in the expected way.

It might be convenient to inform the user of this in some way or modify the code to have a different way of detecting Clover.

Since ATH creates several files in` /private/tmp/.ath` every time it runs and one of them is `hw.txt`, which contains `Powered by Clover` if that is the boot loader in use, you can detect if Clover is the boot loader just by searching for the word Clover in the `hw.txt` file.

This way you can avoid the requirement to install `bdmesg` which, if the user has not installed it manually, causes ATH to not report the boot loader as it should.

Anyway, thanks for your work.

---

Current code with bdmesg:

<img width="348" alt="bdmesg-yes" src="https://github.com/user-attachments/assets/093349d0-ceeb-4a13-b481-bc614c531d56" />

---

Current code without bdmesg:

<img width="345" alt="bdmesg-no" src="https://github.com/user-attachments/assets/f2c1d937-0962-44e6-b8cb-85d66798fef0" />

---

PR not dependent on bdmesg:

<img width="306" alt="code-changed" src="https://github.com/user-attachments/assets/dbd36a73-67ca-4940-a382-f731fc4168e5" />
