### PR TITLE
No need to hide boot loader info textbox

### DIFF
--- a/About This Hack/ViewController.swift
+++ b/About This Hack/ViewController.swift
@@ -117,15 +117,15 @@ class ViewController: NSViewController {
         serialNumber.stringValue = (serialNumber.stringValue == "") ? HCSerialNumber.shared.getSerialNumber() : ""
     }
     
-    @IBAction func hideBlVersion(_ sender: NSButton) {
-        if (blPrefix.isHidden) {
-            blPrefix.isHidden = false
-            blVersion.isHidden = false
-        } else {
-            blPrefix.isHidden = true
-            blVersion.isHidden = true
-        }
-    }
+//    @IBAction func hideBlVersion(_ sender: NSButton) {
+//        if (blPrefix.isHidden) {
+//            blPrefix.isHidden = false
+//            blVersion.isHidden = false
+//        } else {
+//            blPrefix.isHidden = true
+//            blVersion.isHidden = true
+//        }
+//    }
     
     @IBAction func showSystemReport(_ sender: NSButton) {
         NSWorkspace.shared.open(URL(fileURLWithPath: "/System/Library/SystemProfiler/SPPlatformReporter.spreporter"))


### PR DESCRIPTION
Good night. In my opinion there is no need to show/hide the boot loader info as we do with the serial number.
But I could be wrong in not knowing why you developed it like that.
Anyway, thanks for this app.