### PR TITLE
Attempting to fix MacPro7,1 wrong detection

### DIFF
--- a/About This Hack/HardwareCollectors/HCMacModel.swift
+++ b/About This Hack/HardwareCollectors/HCMacModel.swift
@@ -16,22 +16,22 @@ class HCMacModel {
     
     func getModelIdentifier() -> String {
         run("sysctl hw.model | awk '{print $2}' | tr -d '\n'").nilIfEmpty ?? "Unknown"
-
     }
     
     private func getMacName() -> String {
+        
         let infoString = getModelIdentifier()
         let (displaySize, name) = macModels[infoString] ?? (0, "Mac")
         builtInDisplaySize = displaySize
         //return name
-        
-//        // MacPro7,1 OK
-//        let command = "cat \(InitGlobVar.hwFilePath) | grep \"Model Identifier\" | cut -d \":\" -f4"
-//        return run(command).trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty ?? name
 
-        // MacPro7,1 OK
-        let command = "/usr/sbin/sysctl -n hw.model"
+//        // MacPro7,1 OK
+        let command = "cat \(InitGlobVar.hwFilePath) | grep \"Model Identifier\" | cut -d \":\" -f4"
         return run(command).trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty ?? name
+
+         // MacPro7,1 error
+//       let command = "/usr/sbin/sysctl -n hw.model"
+//       return run(command).trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty ?? name
 
 //        // MacPro7,1 error
 //        let command = "ioreg -l | grep product-name | cut -c 28- | sed 's/.\\{2\\}$//'"

--- a/About This Hack/HardwareCollectors/HCMacModel.swift
+++ b/About This Hack/HardwareCollectors/HCMacModel.swift
@@ -25,16 +25,19 @@ class HCMacModel {
         builtInDisplaySize = displaySize
         //return name
         
-        let baseCommand = "defaults read"
-        let plistPath = "~/Library/Preferences/com.apple.SystemProfiler.plist"
-        let key = "\"CPU Names\""
-        let cutCommand = "| cut -sd '\"' -f 4"
-        let uniqCommand = "| uniq"
-
-        // Combine all parts into a single command string
-        let fullCommand = "\(baseCommand) \(plistPath) \(key) \(cutCommand) \(uniqCommand)"
+        let command = run("cat \(InitGlobVar.hwFilePath) | grep \"Model Identifier\" | cut -d \":\" -f2")
+        return run(command).trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty ?? name
         
-        return run(fullCommand).trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty ?? name
+//        let baseCommand = "defaults read"
+//        let plistPath = "~/Library/Preferences/com.apple.SystemProfiler.plist"
+//        let key = "\"CPU Names\""
+//        let cutCommand = "| cut -sd '\"' -f 4"
+//        let uniqCommand = "| uniq"
+//
+//        // Combine all parts into a single command string
+//        let fullCommand = "\(baseCommand) \(plistPath) \(key) \(cutCommand) \(uniqCommand)"
+//        
+//        return run(fullCommand).trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty ?? name
 
     }
     

--- a/About This Hack/HardwareCollectors/HCMacModel.swift
+++ b/About This Hack/HardwareCollectors/HCMacModel.swift
@@ -25,7 +25,7 @@ class HCMacModel {
         builtInDisplaySize = displaySize
         //return name
 
-//        // MacPro7,1 OK
+//      // MacPro7,1 OK
         let command = "cat \(InitGlobVar.hwFilePath) | grep \"Model Identifier\" | cut -d \":\" -f4"
         return run(command).trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty ?? name
 
@@ -33,11 +33,11 @@ class HCMacModel {
 //       let command = "/usr/sbin/sysctl -n hw.model"
 //       return run(command).trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty ?? name
 
-//        // MacPro7,1 error
+          // MacPro7,1 error
 //        let command = "ioreg -l | grep product-name | cut -c 28- | sed 's/.\\{2\\}$//'"
 //        return run(command).trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty ?? name
 //        
-//        // MacPro7,1 error
+          // MacPro7,1 error
 //        let baseCommand = "defaults read"
 //        let plistPath = "~/Library/Preferences/com.apple.SystemProfiler.plist"
 //        let key = "\"CPU Names\""

--- a/About This Hack/HardwareCollectors/HCMacModel.swift
+++ b/About This Hack/HardwareCollectors/HCMacModel.swift
@@ -25,9 +25,19 @@ class HCMacModel {
         builtInDisplaySize = displaySize
         //return name
         
-        let command = run("cat \(InitGlobVar.hwFilePath) | grep \"Model Identifier\" | cut -d \":\" -f2")
+//        // MacPro7,1 OK
+//        let command = "cat \(InitGlobVar.hwFilePath) | grep \"Model Identifier\" | cut -d \":\" -f4"
+//        return run(command).trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty ?? name
+
+        // MacPro7,1 OK
+        let command = "/usr/sbin/sysctl -n hw.model"
         return run(command).trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty ?? name
-        
+
+//        // MacPro7,1 error
+//        let command = "ioreg -l | grep product-name | cut -c 28- | sed 's/.\\{2\\}$//'"
+//        return run(command).trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty ?? name
+//        
+//        // MacPro7,1 error
 //        let baseCommand = "defaults read"
 //        let plistPath = "~/Library/Preferences/com.apple.SystemProfiler.plist"
 //        let key = "\"CPU Names\""

--- a/About This Hack/HardwareCollectors/HCMacModel.swift
+++ b/About This Hack/HardwareCollectors/HCMacModel.swift
@@ -25,28 +25,28 @@ class HCMacModel {
         builtInDisplaySize = displaySize
         //return name
 
-//      // MacPro7,1 OK
+        // MacPro7,1 OK
         let command = "cat \(InitGlobVar.hwFilePath) | grep \"Model Identifier\" | cut -d \":\" -f4"
         return run(command).trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty ?? name
 
-         // MacPro7,1 error
-//       let command = "/usr/sbin/sysctl -n hw.model"
-//       return run(command).trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty ?? name
+        // MacPro7,1 error
+//        let command = "/usr/sbin/sysctl -n hw.model"
+//        return run(command).trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty ?? name
 
-          // MacPro7,1 error
+        // MacPro7,1 error
 //        let command = "ioreg -l | grep product-name | cut -c 28- | sed 's/.\\{2\\}$//'"
 //        return run(command).trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty ?? name
-//        
-          // MacPro7,1 error
+
+        // MacPro7,1 error
 //        let baseCommand = "defaults read"
 //        let plistPath = "~/Library/Preferences/com.apple.SystemProfiler.plist"
 //        let key = "\"CPU Names\""
 //        let cutCommand = "| cut -sd '\"' -f 4"
 //        let uniqCommand = "| uniq"
-//
-//        // Combine all parts into a single command string
+
+        // Combine all parts into a single command string
 //        let fullCommand = "\(baseCommand) \(plistPath) \(key) \(cutCommand) \(uniqCommand)"
-//        
+//
 //        return run(fullCommand).trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty ?? name
 
     }


### PR DESCRIPTION
There are comments from users (including myself) who have noted that version 2.0.2 does not properly detect the MacPro7,1 model.
The new code to get the model information seems to be broken.

In my case, it is displayed as `Hackintosh Extreme Plus (MacPro7,1)` which changes within a few seconds to `iMac (Retina 5K, 27-inch, 2020)` (which is wrong). Cursor is busy (app is unresponsive) while checking for updates. Mac model changes just at the end of the updates check.

Since the SMBIOS model exists in the file `/private/tmp/.ath/hw.txt` in the format `Model Identifier: Mac_model`, we can extract the model from this file in a simpler way that seems to solve this problem.

I have tested it on 3 SMBIOS with success: MacPro7,1, iMacPro1,1 and iMac19,1. On all 3 it seems to work fine and the process of checking for updates is faster and does not stall the application.

I'm not sure if the fix is ​​OK, my level as a developer is low.
I don't have a non-Intel Mac to test this so I don't know if it has any unwanted effects on such Macs.