### PR TITLE
Disabled SIP wrong info both OpenCore and Clover

### DIFF
--- a/About This Hack/HardwareCollectors/HCBootloader.swift
+++ b/About This Hack/HardwareCollectors/HCBootloader.swift
@@ -21,11 +21,16 @@ class HCBootloader {
     }()
     
     private lazy var bootargsInfo: String = {
+    
+        // Commnad in Terminal
+        // nvram -x boot-args 2>/dev/null | grep -A1 "<key>boot-args</key>" | tail -1 | awk -F "<string>" '{print $NF}' | awk -F "</string>" '{print $1}' | tr -d '\n'
         var bootargs = run("nvram -x boot-args 2>/dev/null | grep -A1 \"<key>boot-args</key>\" | tail -1 | awk -F \"<string>\" '{print $NF}' | awk -F \"<\\/string>\" '{print $1}'  | tr -d '\n'")
         
-        if bootargs.isEmpty {
-            bootargs = run("\(InitGlobVar.bdmesgExecID) 2>/dev/null | grep ' boot-args=' | tail -1 | awk -F ' boot-args=' '{print $NF}' | tr -d '\n'")
-        }
+        // Skipped since bdmesg may or may not be present
+        // and cloverInfo is got from InitGlobVar.hwFilePath
+//        if bootargs.isEmpty {
+//            bootargs = run("\(InitGlobVar.bdmesgExecID) 2>/dev/null | grep ' boot-args=' | tail -1 | awk -F ' boot-args=' '{print $NF}' | tr -d '\n'")
+//        }
         
         return bootargs.isEmpty ? "Empty/Unknown" : bootargs
     }()

--- a/About This Hack/HardwareCollectors/HCVersion.swift
+++ b/About This Hack/HardwareCollectors/HCVersion.swift
@@ -105,7 +105,7 @@ class HCVersion {
         // Bootloader is OpenCore or Clover
         if !cloverOCcommand.contains("Apple") {
             
-            let csrConfig = run("ioreg -l | grep csr-active-config | cut -c 38- | cut -c -8")
+            let csrConfig = run("ioreg -l | grep csr-active-config | cut -c 38- | cut -c -8 | tr -d '\n'")
             let sipStatus = (csrConfig == "00000000") ? "Enabled" : "Disabled"
             return "System Integrity Protection: \(sipStatus) \n0x" + csrConfig
             

--- a/About This Hack/InitGlobalVariables.swift
+++ b/About This Hack/InitGlobalVariables.swift
@@ -21,6 +21,9 @@ class InitGlobVar {
     }
     
     static let defaultfileManager      = FileManager.default
+    
+    // Used to check OC/Clover or Apple bootloader
+    static var cloverOC                 = run("sysctl -n machdep.cpu.brand_string")
 
     // Used by UpdateController
     static var athrepositoryURL        = "https://github.com/2009-Nissan-Cube/About-This-Hack"


### PR DESCRIPTION
There are users (including myself) who don't see the correct SIP value when it is fully or partially disabled.
There is even a closed issue ([124](https://github.com/2009-Nissan-Cube/About-This-Hack/issues/124), the user has Clover and the problem is attributed to this).

But I have tried Clover and OpenCore and with both boot loaders the same thing happens. SIP value is enabled 0x00000000 even if disabled.

On Hackintosh and Intel Macs it is easy to get SIP value with the command `ioreg -l | grep csr-active-config | cut -c 38- | cut -c -8`. Returned value is the hexadecimal number to be displayed in the tooltip.

If in `private func getSIPInfo()` we know if the boot loader is OpenCore / Clover or not, we can solve SIP info in tooltip with few lines, without the need of `private func csrActiveConfig()`. I have tested it and it seems to work fine.

I don't have Apple Silicon so I ask you to check if on these machines the command `ioreg -l | grep csr-active-config | cut -c 38- | cut -c -8` is also valid, in which case I would shorten the code to be the same with OpenCore / Clover and with Apple, skipping `private func csrActiveConfig()` in both cases.
But if the command fails on your M2, then options are forked between both types of boot loaders keeping `private func csrActiveConfig()` only for Apple boot loader.

Waiting for this question to be resolved, best regards.

Note: There is also a small change commenting that bdmesg is no longer used to detect Clover.

<img width="602" alt="SIP" src="https://github.com/user-attachments/assets/42a875f6-18d4-4b01-a9af-061f28a1b98a" />
